### PR TITLE
Add VS Code launch configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run argus.py",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/argus.py",
+      "args": [
+        "${workspaceFolder}/sample.txt",
+        "--source-reliability",
+        "0.75",
+        "--tnorm",
+        "min"
+      ]
+    },
+    {
+      "name": "Run fls_intel_analyzer.py",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/fls_intel_analyzer.py",
+      "args": [
+        "${workspaceFolder}/sample.txt",
+        "${workspaceFolder}/analysis_bundle.json",
+        "--t-norm",
+        "product"
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "python.defaultInterpreterPath": "/root/.pyenv/versions/3.12.10/bin/python3",
+  "python.linting.enabled": true,
+  "python.linting.pylintEnabled": true
+}


### PR DESCRIPTION
## Summary
- add VS Code launch configurations for argus.py and fls_intel_analyzer.py
- set Python interpreter path and enable linting via VS Code settings

## Testing
- `python -m py_compile argus.py fls_intel_analyzer.py && echo "py_compile succeeded"`


------
https://chatgpt.com/codex/tasks/task_e_6898515f124c832f9fb9d2dd62dc5528